### PR TITLE
Updated Speed Freeks vehicle wargear entries with descriptions + Big Squiggoth from Imperial Armour

### DIFF
--- a/Orks (1999).cat
+++ b/Orks (1999).cat
@@ -5447,7 +5447,7 @@ Kustom Mega Cannon: 20+150%+100%=70
         <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="475"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="4fb4-db5f-551f-a05d" name="Big Squiggoth (IA)" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="4fb4-db5f-551f-a05d" name="Big Squiggoth (IA)" hidden="false" collective="false" import="true" type="unit" publicationId="f5c8-02b4-8873-cb63" page="13">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -5805,7 +5805,7 @@ The Ork vehicle may shoot in the shooting phase as normal and then resolves an a
             <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="5"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="dfb0-e6ca-d747-dc06" name="Armoured Top" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="dfb0-e6ca-d747-dc06" name="Armoured Top" hidden="false" collective="false" import="true" type="upgrade" publicationId="2b63-6841-db19-e6fa" page="10">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -5825,7 +5825,7 @@ The Ork vehicle may shoot in the shooting phase as normal and then resolves an a
             <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="8"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="cd9f-065e-7b8c-21dd" name="Force Field" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="cd9f-065e-7b8c-21dd" name="Force Field" hidden="false" collective="false" import="true" type="upgrade" publicationId="2b63-6841-db19-e6fa" page="10">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>


### PR DESCRIPTION
Speed Freeks Vehicle Upgrades were missing their descriptions.

<img width="515" height="547" alt="Screenshot 2025-12-29 at 15-29-38 Codex - Armageddon - WarHammer 40k - Codex - Armageddon pdf" src="https://github.com/user-attachments/assets/f7f493d5-47c9-4a79-b91f-4e75c3213251" />
