### PR TITLE
Griffon and Valkyrie added

### DIFF
--- a/Imperial Guard (2003).cat
+++ b/Imperial Guard (2003).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="04bd-002e-d5fe-e9a6" name="Imperial Guard (2003)" revision="12" battleScribeVersion="2.03" authorName="Kris Snyder" library="false" gameSystemId="96e2-b781-50d7-3d18" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="04bd-002e-d5fe-e9a6" name="Imperial Guard (2003)" revision="13" battleScribeVersion="2.03" authorName="Kris Snyder" library="false" gameSystemId="96e2-b781-50d7-3d18" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="3670-6ad0-8988-c35b" name="Officer" hidden="false"/>
     <categoryEntry id="5a7d-a0bb-d5e1-e79a" name="Standard Bearer" hidden="false"/>
@@ -457,6 +457,16 @@
     </entryLink>
     <entryLink import="true" name="Cypher (White Dwarf 281)" hidden="false" id="4ca5-f4e1-1688-bb54" type="selectionEntry" targetId="8fef-9ae0-66c3-1628"/>
     <entryLink import="true" name="Fallen Angels (White Dwarf 281)" hidden="false" id="f175-a48d-3d20-d135" type="selectionEntry" targetId="0f82-b6c4-2a66-d15f"/>
+    <entryLink import="true" name="Griffon (IA)" hidden="false" id="a658-baa5-72c8-1689" type="selectionEntry" targetId="0aa4-275b-24ff-710b">
+      <categoryLinks>
+        <categoryLink targetId="aacb-8a81-62c0-3db8" id="0020-3ada-05e1-9fd8" primary="true" name="Heavy Support"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink import="true" name="Valkrie (IA)" hidden="false" id="7d57-d050-853d-8251" type="selectionEntry" targetId="15fa-a2a9-33a2-7a5e">
+      <categoryLinks>
+        <categoryLink targetId="aacb-8a81-62c0-3db8" id="4bfb-a22e-c19e-7e51" primary="true" name="Heavy Support"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="f6c9-305b-8827-2cb6" name="Command Platoon" hidden="false" collective="false" import="true" type="unit">


### PR DESCRIPTION
- Griffon added to Heavy Support.
- I also added Valkrie to Heavy Support its not listed anywhere and seems like it should be with the other Imperial Navy Air Support.

https://github.com/ksnyder1986/Warhammer-40k-3rd-Edition/issues/339