### PR TITLE
Imperial Guard - 4-4-26

### DIFF
--- a/Imperial Guard (2003).cat
+++ b/Imperial Guard (2003).cat
@@ -8799,8 +8799,8 @@
           <modifiers>
             <modifier type="increment" field="4ed5-2f92-9abc-2870" value="4">
               <repeats>
-                <repeat field="selections" scope="45d8-c175-e5cb-2354" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ae31-c8c8-f45e-60f3" repeats="1" roundUp="false"/>
-                <repeat field="selections" scope="54c0-9145-28d2-3ebf" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3af3-ca0d-2b82-6802" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="45d8-c175-e5cb-2354" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="02b2-6ba9-c7b6-cfdd" repeats="1" roundUp="false"/>
+                <repeat field="selections" scope="54c0-9145-28d2-3ebf" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7df9-8f37-97d4-6fa7" repeats="1" roundUp="false"/>
               </repeats>
             </modifier>
           </modifiers>
@@ -10354,6 +10354,16 @@
       <costs>
         <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="75"/>
       </costs>
+      <selectionEntries>
+        <selectionEntry type="upgrade" import="true" name="Add Towing Carriage" hidden="false" id="c26c-eab8-a5ef-6017" collective="false">
+          <constraints>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="a299-352d-66b3-59b5" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="5"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
     </selectionEntry>
     <selectionEntry id="580e-5f01-017e-c7fa" name="Hydra (IA)" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
@@ -10522,15 +10532,6 @@
             <modifier type="set" field="name" value="2x Lascannon"/>
           </modifiers>
         </infoLink>
-        <infoLink id="c629-5c1d-710e-579f" name="Long Barrelled Autocannon" hidden="false" targetId="48dc-47d4-5d34-3078" type="profile">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="03b5-5686-c89c-c6fd" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </infoLink>
         <infoLink id="5ff1-cff8-8ecb-319f" name="Twin-Linked" hidden="false" targetId="ebe5-6318-0fba-b84c" type="rule"/>
         <infoLink id="69c6-2f2f-972c-62e5" name="Rockits" hidden="false" targetId="8128-a576-6e0a-07da" type="profile">
           <modifiers>
@@ -10544,14 +10545,6 @@
         </infoLink>
       </infoLinks>
       <selectionEntries>
-        <selectionEntry id="03b5-5686-c89c-c6fd" name="Strike Variant" hidden="false" collective="false" import="true" type="upgrade" sortIndex="1">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee15-b5ce-a9ed-4312" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="cbfd-cc83-6643-1436" name="Wing Mounted Hellstrike Missiles" hidden="false" collective="false" import="true" type="upgrade" sortIndex="2">
           <constraints>
             <constraint field="selections" scope="parent" value="4" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc5c-3109-61fc-4ddb" type="max"/>
@@ -10574,6 +10567,49 @@
       <costs>
         <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="145"/>
       </costs>
+      <selectionEntryGroups>
+        <selectionEntryGroup name="Variants" id="f6fe-ba67-7549-ac47" hidden="false" defaultSelectionEntryId="16b2-2cff-8252-74bd" sortIndex="1">
+          <selectionEntries>
+            <selectionEntry type="upgrade" import="true" name="Strike Variant" hidden="false" id="03b5-5686-c89c-c6fd" collective="false" sortIndex="2">
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="ee15-b5ce-a9ed-4312" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="0"/>
+              </costs>
+              <infoLinks>
+                <infoLink name="Rockits" id="77e5-9f81-797f-7ce2" hidden="false" targetId="8128-a576-6e0a-07da" type="profile">
+                  <modifiers>
+                    <modifier type="set" value="Hellstrike Missiles" field="name"/>
+                  </modifiers>
+                </infoLink>
+                <infoLink name="Rockits" id="dd6d-ad38-397b-971b" hidden="false" targetId="8128-a576-6e0a-07da" type="profile">
+                  <modifiers>
+                    <modifier type="set" value="Hellstrike Missiles" field="name"/>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+            </selectionEntry>
+            <selectionEntry type="upgrade" import="true" name="Standard" hidden="false" id="16b2-2cff-8252-74bd" sortIndex="1">
+              <infoLinks>
+                <infoLink name="Long Barrelled Autocannon" id="c629-5c1d-710e-579f" hidden="false" targetId="48dc-47d4-5d34-3078" type="profile">
+                  <modifiers>
+                    <modifier type="set" value="true" field="hidden">
+                      <conditions>
+                        <condition type="equalTo" value="1" field="selections" scope="parent" childId="03b5-5686-c89c-c6fd" shared="true" percentValue="false" includeChildSelections="false" includeChildForces="false"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                </infoLink>
+              </infoLinks>
+            </selectionEntry>
+          </selectionEntries>
+          <constraints>
+            <constraint type="min" value="1" field="selections" scope="parent" shared="true" id="8bf1-a2f5-1dd7-88ea"/>
+            <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="f406-2405-461f-aef2"/>
+          </constraints>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
     </selectionEntry>
     <selectionEntry id="416c-65a1-3ce3-3cce" name="Marauder Bomber (IA)" hidden="false" collective="false" import="true" type="upgrade">
       <modifiers>
@@ -10801,6 +10837,9 @@ Sentry Mode: The gun will fire at the nearest enemy target within 12&quot; that 
                   </costs>
                 </selectionEntry>
               </selectionEntries>
+              <constraints>
+                <constraint type="max" value="1" field="selections" scope="parent" shared="true" id="096b-31ad-b3ca-ab0c"/>
+              </constraints>
             </selectionEntryGroup>
           </selectionEntryGroups>
           <costs>


### PR DESCRIPTION
- Fixed Grenadiers Meltabombs option.
- Fixed Tarantula Sentry Gun Weapon option.
- Fix Lighting Fighter Strike Variant.
- Added Towing Carriage option to Earthshaker Platform.