### PR TITLE
Fix Frag grenades having an empty field for slugga boyz #400 

### DIFF
--- a/Orks (1999).cat
+++ b/Orks (1999).cat
@@ -6440,7 +6440,7 @@ The ammo runt may not be chosen as a casualtiy caused by enemy shooting, but Bla
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfd3-1d2d-d66f-d74b" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="b99c-c735-361a-6fdb" name="Frag Grenades" hidden="false" targetId="9dd4-e950-2419-5934" type="profile"/>
+            <infoLink id="b99c-c735-361a-6fdb" name="Frag Grenades" hidden="false" targetId="9dd4-e950-2419-5934" type="rule"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="1"/>

--- a/Orks (1999).cat
+++ b/Orks (1999).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a32b-2b78-118a-10a5" name="Orks (1999)" revision="12" battleScribeVersion="2.03" library="false" gameSystemId="96e2-b781-50d7-3d18" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="a32b-2b78-118a-10a5" name="Orks (1999)" revision="13" battleScribeVersion="2.03" library="false" gameSystemId="96e2-b781-50d7-3d18" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="7ae7-ec32-6af0-2290" name="Kult of Speed" hidden="false"/>
     <categoryEntry id="838f-024c-52e0-08f2" name="Deth Kopta" hidden="false"/>
@@ -6440,7 +6440,7 @@ The ammo runt may not be chosen as a casualtiy caused by enemy shooting, but Bla
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfd3-1d2d-d66f-d74b" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="b99c-c735-361a-6fdb" name="Frag Grenades" hidden="false" targetId="cedc-c0a1-ffd3-1b51" type="rule"/>
+            <infoLink id="b99c-c735-361a-6fdb" name="Frag Grenades" hidden="false" targetId="9dd4-e950-2419-5934" type="profile"/>
           </infoLinks>
           <costs>
             <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="1"/>


### PR DESCRIPTION
To resolve Frag rules not showing up for slugga boyz in #400 , we changed it to the correct ID (9dd4-e950-2419-5934) present in the rules section.

It has not been tested, but its now populating it inside the developer app after the change. Which lead me to believe its working as intended :)

<img width="582" height="342" alt="image" src="https://github.com/user-attachments/assets/18696446-4d16-47f7-8d71-66d22da39d9b" />


Let me know if you have any questions.