### PR TITLE
Fix Ravenwing veteran sergeant armory access and command squad specia…

### DIFF
--- a/Dark Angels (1999).cat
+++ b/Dark Angels (1999).cat
@@ -1420,7 +1420,7 @@
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6004-a925-4f19-f3b0" type="equalTo"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6004-a925-4f19-f3b0" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2434,7 +2434,7 @@
                   <modifiers>
                     <modifier type="set" field="hidden" value="true">
                       <conditions>
-                        <condition field="selections" scope="parent" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6278-8b7e-7326-ae29" type="equalTo"/>
+                        <condition field="selections" scope="ancestor" value="0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="6278-8b7e-7326-ae29" type="equalTo"/>
                       </conditions>
                     </modifier>
                   </modifiers>
@@ -2461,6 +2461,30 @@
                 <infoLink id="59a6-4329-9cb8-0cb6" name="Close Combat Weapon" hidden="false" targetId="46d5-85f2-d932-f0a2" type="profile"/>
                 <infoLink id="c997-e291-dced-9fa5" name="Space Marine Biker" hidden="false" targetId="b03d-e20c-1e5e-86b8" type="profile"/>
               </infoLinks>
+              <selectionEntries>
+                <selectionEntry id="a1b2-c3d4-e5f6-7890" name="Narthecium" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2c3-d4e5-f6a7-8901" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="c3d4-e5f6-a7b8-9012" name="Narthecium" hidden="false" targetId="cfad-88c2-ae81-cdc1" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="25"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d4e5-f6a7-b8c9-0123" name="Reductor" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5f6-a7b8-c9d0-1234" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="f6a7-b8c9-d0e1-2345" name="Reductor" hidden="false" targetId="ba6f-5067-ce85-aa4b" type="rule"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name="pts" typeId="4ed5-2f92-9abc-2870" value="5"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <entryLinks>
                 <entryLink id="547c-773a-4adb-f664" name="Space Marine Armory" hidden="false" collective="false" import="true" targetId="bfc9-22b8-1379-3112" type="selectionEntryGroup"/>
               </entryLinks>
@@ -2485,6 +2509,9 @@
                 <infoLink id="ad13-4dfa-aadd-3c06" name="Close Combat Weapon" hidden="false" targetId="46d5-85f2-d932-f0a2" type="profile"/>
                 <infoLink id="dd56-34a4-e289-0d3c" name="Space Marine Biker" hidden="false" targetId="b03d-e20c-1e5e-86b8" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="a7b8-c9d0-e1f2-3456" name="Standard Bearer" hidden="false" targetId="6c91-d214-036a-50a2" primary="false"/>
+              </categoryLinks>
               <entryLinks>
                 <entryLink id="b08f-ae7a-fba6-c61f" name="Space Marine Armory" hidden="false" collective="false" import="true" targetId="bfc9-22b8-1379-3112" type="selectionEntryGroup"/>
               </entryLinks>
@@ -2509,6 +2536,9 @@
                 <infoLink id="529d-e632-4596-2671" name="Close Combat Weapon" hidden="false" targetId="46d5-85f2-d932-f0a2" type="profile"/>
                 <infoLink id="4318-967f-5b13-480b" name="Space Marine Biker" hidden="false" targetId="b03d-e20c-1e5e-86b8" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="b8c9-d0e1-f2a3-4567" name="Techmarine" hidden="false" targetId="2e99-a0cf-9812-b860" primary="false"/>
+              </categoryLinks>
               <entryLinks>
                 <entryLink id="24b5-4def-fbe7-0bde" name="Space Marine Armory" hidden="false" collective="false" import="true" targetId="bfc9-22b8-1379-3112" type="selectionEntryGroup"/>
               </entryLinks>


### PR DESCRIPTION
…list items

- Fix veteran sergeant wargear: change scope="parent" to scope="ancestor" in the Space Marine Armory visibility condition on the Ravenwing Sergeant in both Ravenwing Bike Squadron and Ravenwing Bike Command Squadron, so the condition correctly finds the Veteran Sergeant upgrade at the unit level (outside the Bikers selectionEntryGroup)

- Fix Ravenwing Command Squad Techmarine: add Techmarine category link so the Servo-arm becomes available through the shared armory

- Fix Ravenwing Command Squad Standard Bearer: add Standard Bearer category link so the Chapter Banner becomes available through the shared armory

- Fix Ravenwing Command Squad Apothecary: add local Narthecium (25pts) and Reductor (5pts) entries, since the shared armory gates these by a specific Space Marines Apothecary entry ID that the Ravenwing model cannot match