### PR TITLE
Fix: Add Kombi-weapons rule to orks

### DIFF
--- a/Orks (1999).cat
+++ b/Orks (1999).cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a32b-2b78-118a-10a5" name="Orks (1999)" revision="16" battleScribeVersion="2.03" library="false" gameSystemId="96e2-b781-50d7-3d18" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
+<catalogue id="a32b-2b78-118a-10a5" name="Orks (1999)" revision="17" battleScribeVersion="2.03" library="false" gameSystemId="96e2-b781-50d7-3d18" gameSystemRevision="2" xmlns="http://www.battlescribe.net/schema/catalogueSchema" type="catalogue">
   <categoryEntries>
     <categoryEntry id="7ae7-ec32-6af0-2290" name="Kult of Speed" hidden="false"/>
     <categoryEntry id="838f-024c-52e0-08f2" name="Deth Kopta" hidden="false"/>
@@ -6005,7 +6005,7 @@ The Ork vehicle may shoot in the shooting phase as normal and then resolves an a
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a463-feb2-f198-98fd" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="03c3-e66c-83c7-9e04" name="Combi Weapons" hidden="false" targetId="e65f-0536-e057-e2d2" type="rule"/>
+            <infoLink id="03c3-e66c-83c7-9e04" name="Kombi-Weapons" hidden="false" targetId="ae7f-b375-c29b-5232" type="rule"/>
             <infoLink id="c27a-b7b7-c82b-3ce6" name="Shoota" hidden="false" targetId="894f-1760-04e4-77c4" type="profile"/>
             <infoLink id="0639-f4b1-ad9a-9850" name="Rokkit Launcha" hidden="false" targetId="56b9-9d7d-bfdf-0ef7" type="profile"/>
           </infoLinks>
@@ -6018,7 +6018,7 @@ The Ork vehicle may shoot in the shooting phase as normal and then resolves an a
             <constraint field="selections" scope="parent" value="1" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4d5-c9b4-eacf-576c" type="max"/>
           </constraints>
           <infoLinks>
-            <infoLink id="8657-2bba-cc57-7a63" name="Combi Weapons" hidden="false" targetId="e65f-0536-e057-e2d2" type="rule"/>
+            <infoLink id="8657-2bba-cc57-7a63" name="Kombi-Weapons" hidden="false" targetId="ae7f-b375-c29b-5232" type="rule"/>
             <infoLink id="73eb-f6f3-9c8e-3101" name="Shoota" hidden="false" targetId="894f-1760-04e4-77c4" type="profile"/>
             <infoLink id="18dd-c08f-cb76-dd8b" name="Skorcha" hidden="false" targetId="a162-3683-bca7-8f2c" type="profile"/>
           </infoLinks>

--- a/Warhammer 40k 3rd Edition.gst
+++ b/Warhammer 40k 3rd Edition.gst
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<gameSystem id="96e2-b781-50d7-3d18" name="Warhammer 40k 3rd Edition" revision="8" battleScribeVersion="2.03" authorName="Snyder" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
+<gameSystem id="96e2-b781-50d7-3d18" name="Warhammer 40k 3rd Edition" revision="9" battleScribeVersion="2.03" authorName="Snyder" xmlns="http://www.battlescribe.net/schema/gameSystemSchema" type="gameSystem">
   <comment>This is intended to create a catalog of Warhammer 40k at the point when 3rd Edition was replaced with 4th Edition. Prior 3rd Edition books may be added over time.</comment>
   <publications>
     <publication id="263c-b15e-84a3-a711" name="Codex Necrons 3rd Edition" shortName="Necrons" publisher="Codex Necrons" publicationDate="2002"/>
@@ -3777,6 +3777,9 @@ Effect: Used before determining who goes first. If successful, the user&apos;s f
       <description>One use only.
 
 Blind/smoke grenades are used in the Shooting phase instead of the unit firing any weapons. Mark the unit as using its blind/smoke grenades by placing cotton wool around them. A unit cannot assault on the same turn it uses blind/smoke grenades. The blind/smoke screen lasts until the start of the player&apos;s next turn and until then the unit counts as in cover with a 5+ cover save. Because they count as being in cover, models in the unit will also strike first if assaulting, unless the enemy is armed with something like frag grenades, or has an ability that allows them to always strike first.</description>
+    </rule>
+    <rule name="Kombi-Weapons" id="ae7f-b375-c29b-5232" hidden="false" publicationId="7f3a-bc20-c411-2e02" page="34">
+      <description>A kombi-weapon is two weapons nailed/wired/welded together, and gives the Ork a choice of two weapons to fire with. An ork that is armed with Kombi-weapon may choose to fire one of the weapons during the shooting phase. The shoota may be fired any number of times, but the other weapon is only allowed to be fired once per battle. Note that you may not choose to fire both of these weapons at the same time. a kombi-weapon may be upgraded with kustom jobs, but the customising only applies to the shoota part of the weapon.</description>
     </rule>
   </sharedRules>
   <sharedProfiles>


### PR DESCRIPTION
Added the Kombi rule to orcs, as they have a different wording than the regular Combi-rule (it also discusses Kustom jobs which regular Combi rules does not)

This fixes #329.

We still have not populated the regular Combi weapons rules. So that must be fixed as well. I will check my rulebook later on this topic.
